### PR TITLE
Make wait optional

### DIFF
--- a/Sources/prlctl/Model/StoppedVM.swift
+++ b/Sources/prlctl/Model/StoppedVM.swift
@@ -10,8 +10,12 @@ public struct StoppedVM: VMProtocol {
     }
 
     /// Start the VM
-    public func start(runner: ParallelsCommandRunner = DefaultParallelsCommandRunner()) throws {
-        try runner.prlctl("start", uuid, "--wait")
+    public func start(wait: Bool = true, runner: ParallelsCommandRunner = DefaultParallelsCommandRunner()) throws {
+        if wait {
+            try runner.prlctl("start", uuid, "--wait")
+        } else {
+            try runner.prlctl("start", uuid)
+        }
     }
 
     /// Clone the VM

--- a/Tests/prlctlTests/VMTests.swift
+++ b/Tests/prlctlTests/VMTests.swift
@@ -76,10 +76,16 @@ final class VMTests: XCTestCase {
         XCTAssertNotNil(vm.asSuspendedVM())
     }
 
-    func testThatStoppedVMCanBeStarted() throws {
+    func testThatStoppedVMCanBeStartedWithWait() throws {
         let runner = TestCommandRunner()
-        try StoppedVM(uuid: "machine-uuid", name: "machine-name").start(runner: runner)
+        try StoppedVM(uuid: "machine-uuid", name: "machine-name").start(wait: true, runner: runner)
         XCTAssertEqual(runner.command, "prlctl start machine-uuid --wait")
+    }
+
+    func testThatStoppedVMCanBeStartedWithoutWait() throws {
+        let runner = TestCommandRunner()
+        try StoppedVM(uuid: "machine-uuid", name: "machine-name").start(wait: false, runner: runner)
+        XCTAssertEqual(runner.command, "prlctl start machine-uuid")
     }
 
     func testThatStoppedVMCanBeCloned() throws {


### PR DESCRIPTION
Adds support for the Parallels 18 API, which doesn't use the `--wait` argument when starting a VM